### PR TITLE
Enable manual trigger for aggregation workflow

### DIFF
--- a/.github/workflows/vet-aggregate.yml
+++ b/.github/workflows/vet-aggregate.yml
@@ -2,6 +2,7 @@
 # in `sources.list` and updates the `audits.toml` file.
 name: vet-aggregate
 on:
+  workflow_dispatch:
   schedule:
     # Once a day at midnight UTC
     - cron:  '0 0 * * *'


### PR DESCRIPTION
Allow manually triggering aggregation workflow. This can be used to force aggregation as needed without waiting for the cron job to be scheduled.