### PR TITLE
fix: fetch remote branch before force-with-lease push in vet-aggregat…

### DIFF
--- a/.github/workflows/vet-aggregate.yml
+++ b/.github/workflows/vet-aggregate.yml
@@ -50,6 +50,7 @@ jobs:
         BRANCH="automated/vet-aggregate"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git fetch origin "$BRANCH" || true
         git checkout -B "$BRANCH"
         git add audits.toml
         git commit -m "Aggregate new audits"


### PR DESCRIPTION
This pull request makes a minor update to the `vet-aggregate.yml` GitHub Actions workflow to improve branch handling. Specifically, it adds a `git fetch` command to ensure the target branch exists locally before checkout, which helps prevent errors if the branch is missing. Recent `vet-aggregate` has been failing due to this:  https://github.com/OpenDevicePartnership/rust-crate-audits/actions/workflows/vet-aggregate.yml

* Added `git fetch origin "$BRANCH"` to the workflow to ensure the branch is available locally before checking it out.