### PR TITLE
Aggregate audits from more ODP repositories

### DIFF
--- a/audits.toml
+++ b/audits.toml
@@ -104,6 +104,13 @@ criteria = "safe-to-run"
 version = "3.0.11"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.anyhow]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.102"
+notes = "Full audit: vtable-based type-erased Error. All unsafe sound. deny(unsafe_op_in_unsafe_fn). build.rs does rustc feature probing only. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.aquamarine]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -168,6 +175,13 @@ criteria = "safe-to-deploy"
 delta = "1.4.0 -> 1.5.0"
 notes = "No unsafe, no build.rs, no network access; delta adds edition-aware rustc probing and best-effort probe-file cleanup only. Assisted-by: copilot-cli:GPT-5.3-Codex"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.autocfg]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.5.0 -> 1.5.1"
+notes = "Delta 1.5.0->1.5.1: test-only refactor replacing shell wrapper script with self-contained Rust test binary. No library code changes, no unsafe, no build script. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.az]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -406,6 +420,13 @@ notes = "Delta 1.2.41->1.2.62 (21 patch versions): Major env var refactor separa
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.cc]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.45 -> 1.2.63"
+notes = "Delta 1.2.45->1.2.63: env var handling refactor, deterministic archives, deadlock fixes, new targets (HelenOS/relibc/RISC-V/VS2026), clang-cl cross-compile fix. No unsafe code. All changes consistent with build-tool purpose. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.cc]]
 who = "Billy Price <williamp@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "1.2.59 -> 1.2.60"
@@ -491,6 +512,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.3 -> 1.0.4"
 notes = "Delta: macro refactor to tt-munching. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.cfg-if]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.0.4"
+notes = "Delta: macro refactor to tt-munching. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.cfg-if]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -704,6 +732,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.100 -> 0.3.10"
 notes = "Downgrade delta from compat shim to full impl. Unsafe FFI is sound. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.defmt]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.100 -> 0.3.10"
+notes = "Downgrade delta from compat shim to full impl. Unsafe FFI is sound. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.defmt]]
@@ -781,6 +816,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.1.0"
 notes = "Delta: Format impls for fmt::Error and Wrapping, xtensa target. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.defmt]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.1.0"
+notes = "Delta: Format impls for fmt::Error and Wrapping, xtensa target. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.defmt]]
@@ -850,6 +892,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.1 -> 0.4.0"
 notes = "Downgrade delta: removes configurable defmt crate path. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.defmt-macros]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 0.4.0"
+notes = "Downgrade delta: removes configurable defmt crate path. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.defmt-macros]]
@@ -893,6 +942,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.1.0"
 notes = "Delta: adds transparent/bound derive attrs. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt685s-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.defmt-macros]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.1.0"
+notes = "Delta: adds transparent/bound derive attrs. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.defmt-macros]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -968,6 +1024,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.0 -> 0.4.1"
 notes = "Downgrade delta: removes Cbor display hint variant. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt685s-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.defmt-parser]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 0.4.1"
+notes = "Downgrade delta: removes Cbor display hint variant. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.defmt-parser]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -1245,6 +1308,13 @@ delta = "0.7.2 -> 0.8.0"
 notes = "Edition 2024. Bug fix: wakers in Signal::reset. Remove Sized bound from MutexGuard::map. Dependency updates (embedded-io-async 0.7.0, heapless 0.9). Implement futures_sink::Sink. Trusted publisher (lulf)."
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.embassy-sync]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.7.2"
+notes = "Downgrade delta. No new unsafe. Removes futures_sink impls, reverts Signal::reset. no_std crate. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.embassy-time]]
 who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -1508,6 +1578,13 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/lis2d
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
 delta = "0.8.0 -> 0.11.1"
+notes = "Delta: adds embedded-hal 1.x support. No unsafe, test mock library. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.embedded-hal-mock]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.8.0 -> 0.11.1"
 notes = "Delta: adds embedded-hal 1.x support. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/is31fl3743b/refs/heads/main/supply-chain/audits.toml"
 
@@ -1679,6 +1756,13 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/lis2d
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
 version = "0.12.1"
+notes = "Full: no_std time lib. deny(unsafe_code). Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.embedded-time]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+version = "0.12.1"
 notes = "Full: no_std time lib. deny(unsafe_code). No build script. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/bq40z50/refs/heads/main/supply-chain/audits.toml"
 
@@ -1825,6 +1909,13 @@ delta = "0.3.31 -> 0.3.32"
 notes = "Delta: AtomicWaker state-release simplified. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.futures-core]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+notes = "Delta: AtomicWaker state-release simplified. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.futures-macro]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
@@ -1899,6 +1990,13 @@ criteria = "safe-to-deploy"
 delta = "0.8.7 -> 0.8.8"
 notes = "Delta audit: replaces heavy windows crate with lighter windows-link/windows-result + auto-generated bindings (windows-bindgen 0.65.0). Fixes fn-ptr-to-int casts for strict provenance. Improves TLS optimization bug workaround on macOS/Windows (compiler_fence + black_box replacing double thread::current hack). No new unsafe patterns; all changes consistent with stackful coroutine purpose. Assisted-by: GitHub Copilot:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.generator]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.8 -> 0.8.9"
+notes = "Delta: adds aarch64 Windows platform support and tvOS/watchOS cfg. New unsafe in context_init and assembly follows existing x86_64 Windows patterns. No new dependencies or capabilities. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.getrandom]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -2015,6 +2113,13 @@ criteria = "safe-to-run"
 version = "0.9.3"
 notes = "no_std static-friendly collections (Vec, String, Deque, etc.), pulled in transitively by postcard-rpc 0.12. Extensive unsafe for in-place buffer management and atomic operations (inherent to a no-alloc collections crate); no network/fs/process access. build.rs only emits `cargo::rustc-cfg=arm_llsc`/`has_atomic_load_store` based on target triple, no codegen or external commands. Assisted-by: opencode:claude-opus-4.7-1m-internal"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/tmp108/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.heapless]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.9.1"
+notes = "Downgrade: net reduction of unsafe surface. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.heapless]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -2174,6 +2279,13 @@ criteria = "safe-to-deploy"
 version = "0.11.0"
 notes = "Used as a dependency for embassy-imxrt."
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.itoa]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.15 -> 1.0.18"
+notes = "Delta: internal algorithm refactor replacing raw ptr arithmetic with MaybeUninit::write. Unsafe reduced. No build script, no_std. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.jiff]]
 who = "Robert Zieba <robertzieba@microsoft.com>"
@@ -2345,6 +2457,20 @@ criteria = "safe-to-deploy"
 delta = "0.4.27 -> 0.4.28"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.log]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.29 -> 0.4.32"
+notes = "Delta 0.4.29->0.4.32: No new unsafe. Key type now distinguishes static vs borrowed strings; added Display-based ToValue for std::net types (no I/O); MSRV bump to 1.71; typo fixes. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.loom]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.7.2"
+notes = "Concurrency permutation testing tool. ~23 unsafe blocks for lifetime extensions, waker vtable, Arc/UnsafeCell ops - all sound. No build script. std::env for LOOM_* config; std::fs only behind checkpoint feature. No network or process spawning. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.maitake-sync]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -2426,6 +2552,20 @@ criteria = "safe-to-run"
 delta = "2.7.4 -> 2.7.5"
 notes = "Delta: doc typo fixes, removed compiler_builtins. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/is31fl3743b/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.memchr]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.6 -> 2.8.0"
+notes = "Delta: adds owned finder builder methods. No unsafe, no build script, no powerful imports. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.memchr]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.6 -> 2.8.1"
+notes = "Delta 2.7.6->2.8.1: clippy cleanups, owned finder builder APIs (alloc-gated), big-endian aarch64 NEON movemask. New unsafe movemask variant is sound. No new dependencies or ambient capabilities. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.miette]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -2582,6 +2722,13 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/lis2d
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
 delta = "0.4.0 -> 0.3.1"
+notes = "Downgrade: version-only dep bumps. no_std meta-crate. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.num]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.4.0 -> 0.3.1"
 notes = "Downgrade: version-only dep bumps. no_std meta-crate. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/bq40z50/refs/heads/main/supply-chain/audits.toml"
 
@@ -2645,6 +2792,13 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/lis2d
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
 delta = "0.4.2 -> 0.3.1"
+notes = "Downgrade: removes ComplexFloat, bytemuck. Feature subset. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.num-complex]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.4.2 -> 0.3.1"
 notes = "Downgrade: removes ComplexFloat. Feature subset. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/is31fl3743b/refs/heads/main/supply-chain/audits.toml"
 
@@ -2703,6 +2857,13 @@ criteria = "safe-to-run"
 delta = "0.4.1 -> 0.3.2"
 notes = "Downgrade: removes Default impl, ldexp. Pure math. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/lis2dw12-i2c/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.num-rational]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-run"
+delta = "0.4.1 -> 0.3.2"
+notes = "Downgrade: removes Default impl, ldexp. Pure math. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.num-rational]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -2847,6 +3008,13 @@ who = "Robert Zieba <robertzieba@microsoft.com>"
 criteria = "safe-to-run"
 version = "1.70.2"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.paste]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.15"
+notes = "Proc-macro crate for identifier pasting. No unsafe code. Build script only detects rustc version. std::env::var used only for env!() segment feature. All generated code is safe identifiers/literals via proc_macro API. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.pico-de-gallo-hal]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -3036,6 +3204,13 @@ version = "1.4.1"
 notes = "Full audit of pretty_assertions 1.4.1. Pure formatting/diff crate for test assertions. deny(unsafe_code) enforced, no unsafe blocks. No build script (build=false). No proc macros. No filesystem, network, or process access. Dependencies: diff (text diffing), yansi (ANSI colors). Behavior matches description. Assisted-by: GitHub Copilot:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.prettyplease]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.2.37"
+notes = "Full audit: no unsafe code. Build script only reads CARGO_PKG_VERSION. Pure computational syn-to-string pretty-printer. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.proc-macro-crate]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
@@ -3130,6 +3305,13 @@ criteria = "safe-to-deploy"
 delta = "1.0.94 -> 1.0.95"
 notes = "Delta: SourceFile removed, replaced by Span::file(). No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.proc-macro2]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.94 -> 1.0.95"
+notes = "Delta: SourceFile removed, replaced by Span::file(). No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.proc-macro2]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -3344,6 +3526,13 @@ delta = "0.8.5 -> 0.8.10"
 notes = "Delta audit: crate uses #![forbid(unsafe_code)], no build.rs, no proc macros, no powerful imports. Changes are cosmetic: inline format args migration, typo fixes in comments/docs, switched docsrs cfg to docsrs_regex, added Cargo include list, deleted shell test script, minor test additions for negated unicode property classes. No security-relevant changes. Assisted-by: GitHub Copilot:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.regex-syntax]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.10 -> 0.8.11"
+notes = "Delta: single optimization to IntervalSet::push() using binary search + incremental merge. No unsafe, no build script, no proc macros. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.rstest]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-run"
@@ -3404,6 +3593,13 @@ delta = "0.1.24 -> 0.1.25"
 notes = "Delta: version bump, removed compiler_builtins. No code changes. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/is31fl3743b/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.rustc-hash]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.1 -> 2.1.2"
+notes = "Delta: refactors hash_bytes bulk loop, broadens arch support, adds const Default. No unsafe, no_std. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.rustc_version]]
 who = "Felipe Balbi <felipe.balbi@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -3447,6 +3643,13 @@ who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-run"
 delta = "0.3.0 -> 0.3.1"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-mcu/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.scoped-tls]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "Tiny single-file crate, no deps, no build script. Two unsafe sites: unsafe impl Sync for static key (sound - TLS is per-thread) and pointer cast in with() (sound - lifetime scoped by set() closure with drop guard). No fs/net/process access. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.semver]]
 who = "Felipe Balbi <felipe.balbi@microsoft.com>"
@@ -3493,6 +3696,13 @@ version = "1.0.228"
 notes = "Diff is clean-up in proc macros"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.serde_json]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "1.0.149"
+notes = "Full audit: 12 unsafe blocks all sound (repr(transparent) transmutes, from_utf8_unchecked on validated data, WTF-8 encoding). build.rs reads cfg env vars only. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[audits.serde_spanned]]
 who = "jerrysxie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
@@ -3505,6 +3715,13 @@ criteria = "safe-to-deploy"
 delta = "0.6.8 -> 0.6.9"
 notes = "Trivial delta: metadata, lint config, and doc formatting only. No functional code changes, no unsafe, no build script, no I/O. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.shlex]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.0 -> 2.0.1"
+notes = "Delta: 2.0 removes deprecated nul-unsafe APIs (RUSTSEC-2024-0006 follow-up), replaces unsound DerefMut with safe unsafe-fn alternatives (from_bytes, as_bytes_mut). No build script, no proc macros, no powerful imports, no_std-compatible. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.slab]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -3552,6 +3769,13 @@ gated behind target_has_atomic=ptr. No build script, no proc macros, no powerful
 Assisted-by: copilot-chat:claude-opus-4.6
 """
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-services/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.stable_deref_trait]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+notes = "Delta: adds StableDeref for Cow types, sound. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.stable_deref_trait]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -3670,6 +3894,13 @@ criteria = "safe-to-deploy"
 delta = "2.0.109 -> 2.0.99"
 notes = "Downgrade delta: parser logic adjustments. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.syn]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.109 -> 2.0.99"
+notes = "Downgrade delta: parser logic adjustments. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.syn]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -3837,6 +4068,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.109 -> 2.0.104"
 notes = "Downgrade delta: const trait bound parsing changes. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.syn]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.109 -> 2.0.104"
+notes = "Downgrade delta: const trait bound parsing changes. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.syn]]
@@ -3941,6 +4179,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.110 -> 2.0.117"
 notes = "Delta: no_std migration, receiver parsing fix. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.syn]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.110 -> 2.0.117"
+notes = "Delta: no_std migration, receiver parsing fix. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.syn]]
@@ -4023,6 +4268,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.17 -> 2.0.12"
 notes = "Downgrade delta: build.rs generates versioned __private module. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.thiserror]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.17 -> 2.0.12"
+notes = "Downgrade delta: build.rs generates versioned __private module. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.thiserror]]
@@ -4093,6 +4345,13 @@ who = "Jerry Xie <jerryxie@microsoft.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.17 -> 2.0.18"
 notes = "Delta: build.rs match-to-let-else refactor. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.thiserror]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.17 -> 2.0.18"
+notes = "Delta: build.rs match-to-let-else refactor. No new unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.thiserror]]
@@ -4149,6 +4408,13 @@ criteria = "safe-to-deploy"
 delta = "2.0.17 -> 2.0.12"
 notes = "Downgrade delta: __private module refactor. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt685s-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.thiserror-impl]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.17 -> 2.0.12"
+notes = "Downgrade delta: __private module refactor. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.thiserror-impl]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -4212,6 +4478,13 @@ criteria = "safe-to-deploy"
 delta = "2.0.17 -> 2.0.18"
 notes = "Delta: conditional clippy lint allows. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt685s-pac/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.thiserror-impl]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.17 -> 2.0.18"
+notes = "Delta: conditional clippy lint allows. No unsafe. Assisted-by: copilot-cli:claude-opus-4.6"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.thiserror-impl]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -4742,10 +5015,24 @@ version = "1.0.1+wasi-0.2.4"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-mcu/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.windows-link]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Metadata-only delta: version bump and readme field casing. No source code changes. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.windows-link]]
 who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-run"
 delta = "0.2.0 -> 0.2.1"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-mcu/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.windows-result]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = "Windows HRESULT/Error/BOOL/Result types. ~15 unsafe blocks for FFI to kernel32/oleaut32 error APIs and COM vtable calls, all sound. No build script, no proc macros, no fs/net/process access. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.windows-sys]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -4785,6 +5072,13 @@ who = "Felipe Balbi <febalbi@microsoft.com>"
 criteria = "safe-to-run"
 version = "0.61.2"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embedded-mcu/refs/heads/main/supply-chain/audits.toml"
+
+[[audits.windows-sys]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "0.59.0 -> 0.61.2"
+notes = "Auto-generated Windows API FFI bindings. No unsafe blocks, no build script, no proc macros, no_std. Delta switches link dep from windows-targets to windows-link. All changes are mechanical API binding additions/removals. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[audits.windows-targets]]
 who = "Jerry Xie <jerryxie@microsoft.com>"
@@ -5270,6 +5564,13 @@ delta = "0.8.27 -> 0.8.48"
 notes = "Delta: proc macro, generated unsafe is trait impls. Assisted-by: copilot-cli:claude-opus-4.6"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml"
 
+[[audits.zmij]]
+who = "Jerry Xie <jerryxie@microsoft.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.20 -> 1.0.21"
+notes = "Delta: refactors pow10 table to const fn. Unsafe pointer arithmetic bounds verified sound. No API changes. no_std. Assisted-by: GitHub Copilot:claude-opus-4.6 cargo-vet"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml"
+
 [[trusted.aho-corasick]]
 criteria = "safe-to-deploy"
 user-id = 189
@@ -5414,6 +5715,13 @@ aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embed
 criteria = "safe-to-run"
 user-id = 55123
 start = "2022-10-29"
+end = "2027-05-16"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/tmp108/refs/heads/main/supply-chain/audits.toml"
+
+[[trusted.cc]]
+criteria = "safe-to-run"
+trusted-publisher = "github:rust-lang/cc-rs"
+start = "2025-09-01"
 end = "2027-05-16"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/tmp108/refs/heads/main/supply-chain/audits.toml"
 
@@ -5612,6 +5920,13 @@ user-id = 55123
 start = "2024-08-15"
 end = "2026-10-09"
 aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/main/supply-chain/audits.toml"
+
+[[trusted.libc]]
+criteria = "safe-to-deploy"
+user-id = 55123
+start = "2024-08-15"
+end = "2027-06-09"
+aggregated-from = "https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml"
 
 [[trusted.libc]]
 criteria = "safe-to-run"

--- a/sources.list
+++ b/sources.list
@@ -3,6 +3,8 @@ https://raw.githubusercontent.com/OpenDevicePartnership/bq25773/refs/heads/main/
 https://raw.githubusercontent.com/OpenDevicePartnership/bq40z50/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/bq41z50/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/embassy-imxrt/refs/heads/main/supply-chain/audits.toml
+https://raw.githubusercontent.com/OpenDevicePartnership/embassy-npcx/refs/heads/main/supply-chain/audits.toml
+https://raw.githubusercontent.com/OpenDevicePartnership/embedded-batteries/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/embedded-cfu/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/embedded-fans/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/embedded-keyboard-rs/refs/heads/main/supply-chain/audits.toml
@@ -17,7 +19,9 @@ https://raw.githubusercontent.com/OpenDevicePartnership/INA4230/refs/heads/main/
 https://raw.githubusercontent.com/OpenDevicePartnership/is31fl3743b/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/lis2dw12-i2c/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/mcxa-pac/refs/heads/main/supply-chain/audits.toml
+https://raw.githubusercontent.com/OpenDevicePartnership/mec17xx-pac/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt600-fcb/refs/heads/main/supply-chain/audits.toml
+https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt633s-pac/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/mimxrt685s-pac/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/npcx490m-pac/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/odp-embedded-controller/refs/heads/main/platform/dev-imxrt/supply-chain/audits.toml
@@ -28,6 +32,7 @@ https://raw.githubusercontent.com/OpenDevicePartnership/odp-platform-common/refs
 https://raw.githubusercontent.com/OpenDevicePartnership/odp-secure-services/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/odp-utilities/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/patina/refs/heads/main/supply-chain/audits.toml
+https://raw.githubusercontent.com/OpenDevicePartnership/pcal6416a/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/systemview-tracing/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/tmp108/refs/heads/main/supply-chain/audits.toml
 https://raw.githubusercontent.com/OpenDevicePartnership/tps6699x/refs/heads/main/supply-chain/audits.toml


### PR DESCRIPTION
Add supply-chain audit sources for additional public ODP repositories that were not yet tracked: embassy-npcx, embedded-batteries, mec17xx-pac, mimxrt633s-pac, and pcal6416a. These were discovered by scanning the organization for cargo-vet supply-chain directories.

Regenerate audits.toml via `cargo vet aggregate` to include the newly imported audits.

Assisted-by: GitHub Copilot:claude-opus-4.8